### PR TITLE
Fix fatal crawling

### DIFF
--- a/src/main/kotlin/io/mustelidae/grantotter/domain/crawler/SwaggerSpecCrawler.kt
+++ b/src/main/kotlin/io/mustelidae/grantotter/domain/crawler/SwaggerSpecCrawler.kt
@@ -56,7 +56,11 @@ class SwaggerSpecCrawler
         val specs = swaggerSpecFinder.findAll()
 
         for (spec in specs) {
-            this.crawling(spec)
+            try {
+                this.crawling(spec)
+            } catch (e: Exception) {
+                log.error("${spec.name} can't crawing")
+            }
         }
     }
 }


### PR DESCRIPTION
크롤링을 하다가 실패한 경우(Swagger 문서가 잘못되었거나 파싱 오류 등)이에 대한 Doc은 크롤링을 넘기도록 한다.